### PR TITLE
Migrate CI to greenzie/build_and_publish_debs orb 0.1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,101 +1,83 @@
 version: 2.1
 
-########################
-###### REFERENCES ######
-########################
+orbs:
+  greenzie: greenzie/build_and_publish_debs@dev:clone_submodules
 
-debianize_executor: &debianize_executor
-  docker:
-    - image: greenzie/ci-debianize:focal-noetic
-      auth:
-        username: $DOCKERHUB_GREENZIE_USERNAME
-        password: $DOCKERHUB_GREENZIE_PASSWORD
-
-debianize_steps: &debianize_steps
-  # This 'when' is hack which allows us to concatenate list of steps
-  # We cannot combine lists, so this is the best solution we have
-  # See: https://circleci.com/docs/introduction-to-yaml-configurations/#anchors-and-aliases
-  when:
-    condition:
-      equal: [ "true", "true" ]
-    steps:
-      - checkout
-      - run:
-          name: "Generate Changelogs"
-          command: greenzie-release changelog -r "${ROS_DISTRO}"
-      - run:
-          name: "Package debs (debuild)"
-          command: GITHUB_WORKSPACE="$PWD" greenzie-debianize all
-
-########################
-######### JOBS #########
-########################
-
-jobs:
-  debian_build:
-    <<: *debianize_executor
-    resource_class: small
-    steps:
-      - <<: *debianize_steps
-      - store_artifacts:
-          path: /debians
-      - run:
-          name: "Move debians"
-          command: install -D -t /debians/artifacts/ /debians/*
-      - persist_to_workspace:
-          root: /debians
-          paths:
-            - '*'
-
-  arm32_debian_build:
-    <<: *debianize_executor
-    resource_class: arm.medium
-    steps:
-      - <<: *debianize_steps
-      - store_artifacts:
-          path: /debians
-      - run:
-          name: "Move debians"
-          command: install -D -t /debians/arm32_artifacts/ /debians/*
-      - persist_to_workspace:
-          root: /debians
-          paths:
-            - '*'
-
-  deploy:
-    docker:
-      - image: greenzie/aptly:3.19.1-focal-noetic
-        auth:
-          username: $DOCKERHUB_GREENZIE_USERNAME
-          password: $DOCKERHUB_GREENZIE_PASSWORD
-    resource_class: small
-    steps:
-      - add_ssh_keys
-      - attach_workspace:
-          at: /debians
-      - run:
-          name: Deploy to aptly.greenzie.com
-          environment:
-            SERVER_HOSTNAME: aptly.greenzie.com
-          command: |
-            aptly repo deploy -r experimental -n "${CIRCLE_BUILD_NUM}" -p "/debians/artifacts"
-            aptly repo deploy -r arm32-experimental -n "${CIRCLE_BUILD_NUM}" -p "/debians/arm32_artifacts"
-
-########################
-####### WORKFLOWS ######
-########################
+parameters:
+  manual-bobcat-deploy:
+    type: boolean
+    default: false
 
 workflows:
   version: 2
   pushbuild:
+    unless: << pipeline.parameters.manual-bobcat-deploy >>
     jobs:
-      - debian_build
-      - arm32_debian_build
-      - deploy:
+      # Build jobs
+      - greenzie/debian_build:
+          name: "amd_debian_build"
+          platform: amd64
+          executor: greenzie/debianize_amd64
+          clone_submodules: false
+
+      - greenzie/debian_build:
+          name: "arm64_debian_build"
+          platform: arm64
+          executor: greenzie/debianize_arm64
+          clone_submodules: false
+
+      # Deployment jobs
+      - greenzie/debian_deploy_experimental:
+          name: "deploy_amd64_greenzie"
+          context: GREENZIE
           filters:
             branches:
               only:
                 - noetic
           requires:
-            - debian_build
-            - arm32_debian_build
+            - amd_debian_build
+
+      - greenzie/debian_deploy_experimental:
+          name: "deploy_arm64_greenzie"
+          context: GREENZIE
+          architecture: arm64
+          filters:
+            branches:
+              only:
+                - noetic
+          requires:
+            - arm64_debian_build
+
+      - greenzie/debian_deploy_experimental:
+          context: GREENZIE
+          name: "deploy_all_bobcat"
+          server_hostname: bobcat
+          filters:
+            branches:
+              only:
+                - noetic
+          requires:
+            - arm64_debian_build
+            - amd_debian_build
+  
+  manualdeploy:
+    when: << pipeline.parameters.manual-bobcat-deploy >>
+    jobs:
+      # Build jobs
+      - greenzie/debian_build:
+          name: "amd_debian_build"
+          platform: amd64
+          executor: greenzie/debianize_amd64
+
+      - greenzie/debian_build:
+          name: "arm64_debian_build"
+          platform: arm64
+          executor: greenzie/debianize_arm64
+
+      - greenzie/debian_deploy_experimental:
+          context: GREENZIE
+          name: "manual_deploy_all_bobcat"
+          server_hostname: bobcat
+          requires:
+            - arm64_debian_build
+            - amd_debian_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,30 +28,6 @@ workflows:
           executor: greenzie/debianize_arm64
           generate_changelog: true
 
-      # Deployment jobs
-      - greenzie/debian_deploy_experimental:
-          name: "deploy_all_greenzie"
-          context: GREENZIE
-          filters:
-            branches:
-              only:
-                - noetic
-          requires:
-            - amd_debian_build
-            - arm64_debian_build
-
-      - greenzie/debian_deploy_experimental:
-          context: GREENZIE
-          name: "deploy_all_bobcat"
-          server_hostname: bobcat
-          filters:
-            branches:
-              only:
-                - noetic
-          requires:
-            - arm64_debian_build
-            - amd_debian_build
-  
   manualdeploy:
     when: << pipeline.parameters.manual-bobcat-deploy >>
     jobs:
@@ -71,8 +47,15 @@ workflows:
           generate_changelog: true
 
       - greenzie/debian_deploy_experimental:
+          name: "deploy_all_greenzie"
           context: GREENZIE
-          name: "manual_deploy_all_bobcat"
+          requires:
+            - amd_debian_build
+            - arm64_debian_build
+
+      - greenzie/debian_deploy_experimental:
+          context: GREENZIE
+          name: "deploy_all_bobcat"
           server_hostname: bobcat
           requires:
             - arm64_debian_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  greenzie: greenzie/build_and_publish_debs@dev:clone_submodules
+  greenzie: greenzie/build_and_publish_debs@0.1.1
 
 parameters:
   manual-bobcat-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,12 +16,14 @@ workflows:
       # Build jobs
       - greenzie/debian_build:
           name: "amd_debian_build"
+          context: GREENZIE
           platform: amd64
           executor: greenzie/debianize_amd64
           clone_submodules: false
 
       - greenzie/debian_build:
           name: "arm64_debian_build"
+          context: GREENZIE
           platform: arm64
           executor: greenzie/debianize_arm64
           clone_submodules: false
@@ -66,11 +68,13 @@ workflows:
       # Build jobs
       - greenzie/debian_build:
           name: "amd_debian_build"
+          context: GREENZIE
           platform: amd64
           executor: greenzie/debianize_amd64
 
       - greenzie/debian_build:
           name: "arm64_debian_build"
+          context: GREENZIE
           platform: arm64
           executor: greenzie/debianize_arm64
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,23 +14,23 @@ workflows:
     unless: << pipeline.parameters.manual-bobcat-deploy >>
     jobs:
       # Build jobs
-      - greenzie/debian_build:
+      - greenzie/debian_build_simple:
           name: "amd_debian_build"
           context: GREENZIE
           platform: amd64
           executor: greenzie/debianize_amd64
-          clone_submodules: false
+          generate_changelog: false
 
-      - greenzie/debian_build:
+      - greenzie/debian_build_simple:
           name: "arm64_debian_build"
           context: GREENZIE
           platform: arm64
           executor: greenzie/debianize_arm64
-          clone_submodules: false
+          generate_changelog: false
 
       # Deployment jobs
       - greenzie/debian_deploy_experimental:
-          name: "deploy_amd64_greenzie"
+          name: "deploy_all_greenzie"
           context: GREENZIE
           filters:
             branches:
@@ -38,16 +38,6 @@ workflows:
                 - noetic
           requires:
             - amd_debian_build
-
-      - greenzie/debian_deploy_experimental:
-          name: "deploy_arm64_greenzie"
-          context: GREENZIE
-          architecture: arm64
-          filters:
-            branches:
-              only:
-                - noetic
-          requires:
             - arm64_debian_build
 
       - greenzie/debian_deploy_experimental:
@@ -66,17 +56,19 @@ workflows:
     when: << pipeline.parameters.manual-bobcat-deploy >>
     jobs:
       # Build jobs
-      - greenzie/debian_build:
+      - greenzie/debian_build_simple:
           name: "amd_debian_build"
           context: GREENZIE
           platform: amd64
           executor: greenzie/debianize_amd64
+          generate_changelog: false
 
-      - greenzie/debian_build:
+      - greenzie/debian_build_simple:
           name: "arm64_debian_build"
           context: GREENZIE
           platform: arm64
           executor: greenzie/debianize_arm64
+          generate_changelog: false
 
       - greenzie/debian_deploy_experimental:
           context: GREENZIE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,14 +19,14 @@ workflows:
           context: GREENZIE
           platform: amd64
           executor: greenzie/debianize_amd64
-          generate_changelog: false
+          generate_changelog: true
 
       - greenzie/debian_build_simple:
           name: "arm64_debian_build"
           context: GREENZIE
           platform: arm64
           executor: greenzie/debianize_arm64
-          generate_changelog: false
+          generate_changelog: true
 
       # Deployment jobs
       - greenzie/debian_deploy_experimental:
@@ -61,14 +61,14 @@ workflows:
           context: GREENZIE
           platform: amd64
           executor: greenzie/debianize_amd64
-          generate_changelog: false
+          generate_changelog: true
 
       - greenzie/debian_build_simple:
           name: "arm64_debian_build"
           context: GREENZIE
           platform: arm64
           executor: greenzie/debianize_arm64
-          generate_changelog: false
+          generate_changelog: true
 
       - greenzie/debian_deploy_experimental:
           context: GREENZIE


### PR DESCRIPTION
Replaces the raw YAML CI config with the `greenzie/build_and_publish_debs` orb (`0.1.1`). The orb-based config was already drafted in `orensbruli/ci_with_orbs`; this PR bumps it to the stable release and opens it for review.